### PR TITLE
Fix 'open-url' on macOS

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "start": "electron .",
     "rebuild": "npm rebuild --runtime=electron --target=1.7.9 --disturl=https://atom.io/download/atom-shell --build-from-source",
     "postinstall": "npm run rebuild",
-    "package": "electron-packager ."
+    "package": "electron-packager . --appBundleId=\"net.safe.app.base.mock\""
   },
   "repository": "https://github.com/hunterlester/safe-app-base",
   "author": "Hunter Lester <hunter.lester@maidsafe.net",

--- a/renderer.js
+++ b/renderer.js
@@ -6,10 +6,14 @@ let safeApp = require('@maidsafe/safe-node-app');
 let ipcRenderer = require('electron').ipcRenderer;
 const isDevMode = process.execPath.match(/[\\/]electron/);
 
+const electron = require('electron');
+const app = (process.type === 'renderer') ? electron.remote.app : electron.app;
+
 const appInfo = {
-	'id': 'net.safe.app.base.mock',
-	'name': 'SAFE app base',
-	'vendor': 'MaidSafe Ltd.'
+	id: 'net.safe.app.base.mock',
+	name: 'SAFE app base',
+	vendor: 'MaidSafe Ltd.',
+	customExecPath: isDevMode ? `${process.execPath} ${app.getAppPath()}` : app.getPath('exe')
 }
 
 // OSX: Add bundle for electron in dev mode

--- a/renderer.js
+++ b/renderer.js
@@ -4,11 +4,17 @@
 let shell = require('electron').shell;
 let safeApp = require('@maidsafe/safe-node-app');
 let ipcRenderer = require('electron').ipcRenderer;
+const isDevMode = process.execPath.match(/[\\/]electron/);
 
 const appInfo = {
 	'id': 'net.safe.app.base.mock',
 	'name': 'SAFE app base',
 	'vendor': 'MaidSafe Ltd.'
+}
+
+// OSX: Add bundle for electron in dev mode
+if (isDevMode && process.platform === 'darwin') {
+  appInfo.bundle = 'com.github.electron';
 }
 
 const containers = {

--- a/yarn.lock
+++ b/yarn.lock
@@ -15,8 +15,8 @@
     weak "^1.0.1"
 
 "@types/node@^7.0.18":
-  version "7.0.48"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-7.0.48.tgz#24bfdc0aa82e8f6dbd017159c58094a2e06d0abb"
+  version "7.0.49"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-7.0.49.tgz#f43777edd31822d6bcb50735a76c7f301d7b3121"
 
 abbrev@1:
   version "1.1.1"


### PR DESCRIPTION
By not having some macOS specific build properties set, the application would not successfully hear back from the SAFE Browser after authentication. This results in the application not printing the MutableData Structure to the console. This pull request fixes this issue.